### PR TITLE
added dependency on mime module to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "./src/api",
   "homepage": "https://github.com/foldersjs/folders",
   "dependencies": {
+    "mime": "^1.3.4"
   },
   "devDependencies": {
     "gulp": "3.x",


### PR DESCRIPTION
It seems the commit https://github.com/foldersjs/folders/commit/166adbf946764c72b68f45936e0713718c7a2f29 added a dependency on the mime module, which is not declared in the package.json of this project and thus breaks projects depending on the master branch of this project. This pull request should fix that.
